### PR TITLE
Symfony 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,19 @@ matrix:
         - php: 5.6
           env: SYMFONY_VERSION=3.2.*
         - php: 5.6
-          env: SYMFONY_VERSION=3.3.*@dev
+          env: SYMFONY_VERSION=3.3.*
+        - php: 5.6
+          env: SYMFONY_VERSION=3.4.*
+        - php: 7.1
+          env: SYMFONY_VERSION=4.0.*
+        - php: 7.1
+          env: SYMFONY_VERSION=4.1.*
+        - php: 7.1
+          env: SYMFONY_VERSION=4.2.*
+        - php: 7.1
+          env: SYMFONY_VERSION=4.3.*
     allow_failures:
-        - env: SYMFONY_VERSION=3.3.*@dev
+        - env: SYMFONY_VERSION=4.3.*
 
 notifications:
     email: geloen.eric@gmail.com

--- a/DependencyInjection/Compiler/ResourceCompilerPass.php
+++ b/DependencyInjection/Compiler/ResourceCompilerPass.php
@@ -39,8 +39,8 @@ class ResourceCompilerPass implements CompilerPassInterface
                 $parameter,
                 array_merge(
                     [
-                        'IvoryFormExtraBundle:Form:javascript.html.twig',
-                        'IvoryFormExtraBundle:Form:stylesheet.html.twig',
+                        '@IvoryFormExtra/Form/javascript.html.twig',
+                        '@IvoryFormExtra/Form/stylesheet.html.twig',
                     ],
                     $container->getParameter($parameter)
                 )

--- a/Resources/config/templating.xml
+++ b/Resources/config/templating.xml
@@ -6,7 +6,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
 >
     <services>
-        <service id="ivory_form_extra.templating.helper" class="Ivory\FormExtraBundle\Templating\FormExtraHelper">
+        <service id="ivory_form_extra.templating.helper" class="Ivory\FormExtraBundle\Templating\FormExtraHelper" public="true">
             <argument type="service" id="templating.form.renderer" />
             <tag name="templating.helper" alias="ivory_form_extra" />
         </service>

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -6,7 +6,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
 >
     <services>
-        <service id="ivory_form_extra.twig.extension" class="Ivory\FormExtraBundle\Twig\FormExtraExtension">
+        <service id="ivory_form_extra.twig.extension" class="Ivory\FormExtraBundle\Twig\FormExtraExtension" public="true">
             <argument type="service" id="twig.form.renderer" />
             <tag name="twig.extension" />
         </service>

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -7,7 +7,7 @@
 >
     <services>
         <service id="ivory_form_extra.twig.extension" class="Ivory\FormExtraBundle\Twig\FormExtraExtension" public="true">
-            <argument type="service" id="twig.form.renderer" />
+            <argument>twig.form.renderer</argument>
             <tag name="twig.extension" />
         </service>
     </services>

--- a/Tests/DependencyInjection/Compiler/ResourceCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ResourceCompilerPassTest.php
@@ -56,8 +56,8 @@ class ResourceCompilerPassTest extends AbstractTestCase
             ->with(
                 $this->identicalTo($parameter),
                 $this->identicalTo([
-                    'IvoryFormExtraBundle:Form:javascript.html.twig',
-                    'IvoryFormExtraBundle:Form:stylesheet.html.twig',
+                    '@IvoryFormExtra/Form/javascript.html.twig',
+                    '@IvoryFormExtra/Form/stylesheet.html.twig',
                     $template,
                 ])
             );

--- a/Tests/Fixtures/views/Twig/javascript_custom.html.twig
+++ b/Tests/Fixtures/views/Twig/javascript_custom.html.twig
@@ -1,11 +1,11 @@
 {% block text_javascript %}
-{% spaceless %}
+{% apply spaceless %}
     <script type="text/javascript">text-javascript</script>
-{% endspaceless %}
+{% endapply %}
 {% endblock %}
 
 {% block submit_javascript %}
-{% spaceless %}
+{% apply spaceless %}
     <script type="text/javascript">submit-javascript</script>
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/Tests/Fixtures/views/Twig/javascript_inheritance.html.twig
+++ b/Tests/Fixtures/views/Twig/javascript_inheritance.html.twig
@@ -1,11 +1,11 @@
 {% block text_javascript %}
-{% spaceless %}
+{% apply spaceless %}
     <script type="text/javascript">text-javascript</script>
-{% endspaceless %}
+{% endapply %}
 {% endblock %}
 
 {% block button_javascript %}
-{% spaceless %}
+{% apply spaceless %}
     <script type="text/javascript">button-javascript</script>
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/Tests/Fixtures/views/Twig/stylesheet_custom.html.twig
+++ b/Tests/Fixtures/views/Twig/stylesheet_custom.html.twig
@@ -1,11 +1,11 @@
 {% block text_stylesheet %}
-{% spaceless %}
+{% apply spaceless %}
     <style type="text/css">text-stylesheet</style>
-{% endspaceless %}
+{% endapply %}
 {% endblock %}
 
 {% block submit_stylesheet %}
-{% spaceless %}
+{% apply spaceless %}
     <style type="text/css">submit-stylesheet</style>
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/Tests/Fixtures/views/Twig/stylesheet_inheritance.html.twig
+++ b/Tests/Fixtures/views/Twig/stylesheet_inheritance.html.twig
@@ -1,11 +1,11 @@
 {% block text_stylesheet %}
-{% spaceless %}
+{% apply spaceless %}
     <style type="text/css">text-stylesheet</style>
-{% endspaceless %}
+{% endapply %}
 {% endblock %}
 
 {% block button_stylesheet %}
-{% spaceless %}
+{% apply spaceless %}
     <style type="text/css">button-stylesheet</style>
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/Tests/Twig/FormExtraExtensionTest.php
+++ b/Tests/Twig/FormExtraExtensionTest.php
@@ -45,7 +45,7 @@ class FormExtraExtensionTest extends AbstractTestCase
      */
     protected function setUp()
     {
-        $this->twig = new \Twig_Environment(new \Twig_Loader_Filesystem([
+        $this->twig = new \Twig_Environment(new \Twig\Loader\FilesystemLoader([
             __DIR__.'/../../Resources/views/Form',
             __DIR__.'/../Fixtures/views/Twig',
         ]));

--- a/Tests/Twig/FormExtraExtensionTest.php
+++ b/Tests/Twig/FormExtraExtensionTest.php
@@ -18,6 +18,7 @@ use Symfony\Bridge\Twig\Form\TwigRenderer;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\Forms;
 
 /**
@@ -51,27 +52,29 @@ class FormExtraExtensionTest extends AbstractTestCase
         ]));
 
         $this->formFactory = Forms::createFormFactory();
-        $this->formRenderer = new TwigRenderer(new TwigRendererEngine(
+        $this->formRenderer = new FormRenderer(new TwigRendererEngine(
             ['javascript.html.twig', 'stylesheet.html.twig'],
             $this->twig
         ));
 
         $this->twig->addExtension(new FormExtraExtension());
 
-        if (!method_exists(FormExtension::class, '__get')) {
-            $this->twig->addExtension(new FormExtension($this->formRenderer));
-        } else {
+//        if (!method_exists(FormExtension::class, '__get')) {
+//
+////            $this->twig->addExtension(new FormExtension($this->formRenderer));
+//            $this->twig->addExtension(new FormExtension());
+//        } else {
             $this->twig->addExtension(new FormExtension());
 
-            $loader = $this->createMock('Twig_RuntimeLoaderInterface');
+            $loader = $this->createMock(\Twig\RuntimeLoader\RuntimeLoaderInterface::class );
             $loader
                 ->expects($this->once())
                 ->method('load')
-                ->with($this->identicalTo('Symfony\Bridge\Twig\Form\TwigRenderer'))
+                ->with($this->identicalTo('Symfony\Component\Form\FormRenderer'))
                 ->will($this->returnValue($this->formRenderer));
 
             $this->twig->addRuntimeLoader($loader);
-        }
+//        }
     }
 
     public function testDefaultJavascriptFragment()

--- a/Twig/FormExtraExtension.php
+++ b/Twig/FormExtraExtension.php
@@ -16,7 +16,7 @@ use Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode;
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class FormExtraExtension extends \Twig_Extension
+class FormExtraExtension extends \Twig\Extension\AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/Twig/FormExtraExtension.php
+++ b/Twig/FormExtraExtension.php
@@ -12,11 +12,13 @@
 namespace Ivory\FormExtraBundle\Twig;
 
 use Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class FormExtraExtension extends \Twig\Extension\AbstractExtension
+class FormExtraExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}
@@ -29,8 +31,8 @@ class FormExtraExtension extends \Twig\Extension\AbstractExtension
         ];
 
         return [
-            new \Twig_SimpleFunction('form_javascript', null, $options),
-            new \Twig_SimpleFunction('form_stylesheet', null, $options),
+            new TwigFunction('form_javascript', null, $options),
+            new TwigFunction('form_stylesheet', null, $options),
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,17 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0",
-        "symfony/form": "^2.7|^3.0|^4.0",
-        "symfony/framework-bundle": "^2.7|^3.0|^4.0"
+        "php": "^7.0",
+        "symfony/form": "^3.2|^4.0",
+        "symfony/framework-bundle": "^3.2|^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",
         "phpunit/phpunit": "^5.0",
-        "symfony/phpunit-bridge": "^2.7|^3.0|^4.0",
-        "symfony/templating": "^2.7|^3.0|^4.0",
-        "symfony/twig-bridge": "^2.7|^3.0|^4.0",
-        "twig/twig": "^1.18|^2.0"
+        "symfony/phpunit-bridge": "^3.0|^4.0",
+        "symfony/templating": "^3.0|^4.0",
+        "symfony/twig-bridge": "^3.0|^4.0",
+        "twig/twig": "^2.0"
     },
     "suggest": {
         "symfony/twig-bridge": "Allows to use Twig templates"

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
     ],
     "require": {
         "php": "^5.6|^7.0",
-        "symfony/form": "^2.7|^3.0",
-        "symfony/framework-bundle": "^2.7|^3.0"
+        "symfony/form": "^2.7|^3.0|^4.0",
+        "symfony/framework-bundle": "^2.7|^3.0|^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",
         "phpunit/phpunit": "^5.0",
-        "symfony/phpunit-bridge": "^2.7|^3.0",
-        "symfony/templating": "^2.7|^3.0",
-        "symfony/twig-bridge": "^2.7|^3.0",
-        "twig/twig": "^1.18"
+        "symfony/phpunit-bridge": "^2.7|^3.0|^4.0",
+        "symfony/templating": "^2.7|^3.0|^4.0",
+        "symfony/twig-bridge": "^2.7|^3.0|^4.0",
+        "twig/twig": "^1.18|^2.0"
     },
     "suggest": {
         "symfony/twig-bridge": "Allows to use Twig templates"


### PR DESCRIPTION
I've gone through the network of forks and cherry-picked work that makes the bundle compatible with Symfony 4. As a result, support for PHP 5.6, Symfony 2.x, and Twig 1.x has been dropped.

Resolves #5.